### PR TITLE
small fix

### DIFF
--- a/jquery.observe_field.js
+++ b/jquery.observe_field.js
@@ -1,7 +1,7 @@
 // jquery.observe_field.js
 //
 
-jQuery.fn.observe_field = function(frequency, callback) {
+jjQuery.fn.observe_field = function(frequency, callback) {
 
   return this.each(function(){
     var element = $(this);
@@ -14,13 +14,19 @@ jQuery.fn.observe_field = function(frequency, callback) {
         element.map(callback); // invokes the callback on the element
       }
     };
-    chk();
+
     frequency = frequency * 1000; // translate to milliseconds
-    var ti = setInterval(chk, frequency);
+
+		element.bind('blur',function() { // stop on focus lost
+			this.ti && clearInterval(this.ti);
+    });
+
+    this.ti = setInterval(chk, frequency);
+
     // reset counter after user interaction
     element.bind('keyup', function() {
-      ti && clearInterval(ti);
-      ti = setInterval(chk, frequency);
+      this.ti && clearInterval(this.ti);
+      this.ti = setInterval(chk, frequency);
     });
   });
 


### PR DESCRIPTION
- changed to make consequental keydowns reset the observation timer (it does not with safari in my case until I fixed it)
- there is no use to check it after blir event until next keydown; if somebody wants to set value and imitate keydown it can just do it or call callback directly
