### PR TITLE
Fix bug in IE9 when observed elements are removed from the DOM

### DIFF
--- a/jquery.observe_field.js
+++ b/jquery.observe_field.js
@@ -12,11 +12,20 @@
       var prev = $this.val();
 
       var check = function() {
+        if(removed()){ // if removed clear the interval and don't fire the callback
+          if(ti) clearInterval(ti);
+          return;
+        }
+
         var val = $this.val();
         if(prev != val){
           prev = val;
           $this.map(callback); // invokes the callback on $this
         }
+      };
+
+      var removed = function() {
+        return $this.closest('html').length == 0
       };
 
       var reset = function() {
@@ -36,4 +45,3 @@
   };
 
 })( jQuery );
-


### PR DESCRIPTION
Hi @splendeo,

I stumbled upon a bug in IE9 when using `observe_field` on elements that were eventually removed from the DOM. The timer kept firing after the elements were removed, causing erroneous callbacks. This patch first checks to make sure the element is still on the page, and if not clears the timer and stops checking for updates.

To replicate in IE9:

``` html
<html>
<head>
  <!-- load jquery and jquery.observe_field !-->
<body>
  <input type="text" id="vanish" value="First you see me"></input>
  <button id="remove">Remove</button>
​  <script>
    $('#vanish').observe_field(1, function(){
      alert("I've changed .. or have I?");
    });

    $('#remove').click(function(){ $('#vanish').remove(); });
  </script>
</body>
```

Clicking remove will fire the alert when it should instead never be triggered. I [tried coding this up](http://jsfiddle.net/uEaVH/) with jsFiddle but apparently IE9 doesn't play nice with that site.

If there is anything you'd like me to change just let me know. Thanks! :smile:

Jordan
